### PR TITLE
Implement rabbitprobe CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Rabbitmq-link-test-tools
+# RabbitMQ Link Test Tools
+
+This project provides a CLI utility `rabbitprobe` to probe RabbitMQ connectivity and send load without declaring any broker entities. The tool is designed for high frequency link monitoring and lightweight load testing.
+
+## Features
+
+- **Connection manager** with automatic reconnect and downtime logging.
+- **Probe engine** publishing ping messages every few hundred milliseconds.
+- **Send command** to publish random payloads for load testing.
+- **Prometheus metrics** exposed via `--metrics-port`.
+- **Rotating logs** written to console and optional file.
+
+## Building
+
+```
+go build ./cmd/rabbitprobe
+```
+
+## Example
+
+Start a probe:
+
+```
+./rabbitprobe --addrs amqp://guest:guest@localhost:5672 probe start --ex probe.ex --rk ping --interval 200ms
+```
+
+Send 100 messages:
+
+```
+./rabbitprobe send --ex data.ex --rk test --size 1024 --count 100
+```

--- a/cmd/rabbitprobe/main.go
+++ b/cmd/rabbitprobe/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/example/rabbitprobe/internal/cmd"
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/rabbitprobe
+
+go 1.24.3

--- a/internal/cmd/probe.go
+++ b/internal/cmd/probe.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/example/rabbitprobe/internal/probe"
+)
+
+var (
+	probeEx       string
+	probeRK       string
+	probeInterval time.Duration
+	probeCtx      context.Context
+	probeCancel   context.CancelFunc
+)
+
+func newProbeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "probe",
+		Short: "start or stop probe",
+	}
+
+	start := &cobra.Command{
+		Use:   "start",
+		Short: "start probe",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mgr, log, ctx, cancel := setup()
+			probeCtx = ctx
+			probeCancel = cancel
+			eng := probe.New(mgr, probeEx, probeRK, probeInterval, log)
+			go eng.Start(ctx)
+			<-ctx.Done()
+			return nil
+		},
+	}
+	start.Flags().StringVar(&probeEx, "ex", "", "exchange")
+	start.Flags().StringVar(&probeRK, "rk", "", "routing key")
+	start.Flags().DurationVar(&probeInterval, "interval", 200*time.Millisecond, "probe interval")
+
+	stop := &cobra.Command{
+		Use:   "stop",
+		Short: "stop probe",
+		Run: func(cmd *cobra.Command, args []string) {
+			if probeCancel != nil {
+				probeCancel()
+			}
+		},
+	}
+	cmd.AddCommand(start, stop)
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/example/rabbitprobe/internal/conn"
+	"github.com/example/rabbitprobe/internal/logger"
+	"github.com/example/rabbitprobe/internal/metrics"
+)
+
+var (
+	addrs       string
+	vhost       string
+	logFile     string
+	metricsPort int
+)
+
+// rootCmd is the base command.
+var rootCmd = &cobra.Command{
+	Use:   "rabbitprobe",
+	Short: "RabbitMQ link probe tool",
+}
+
+// Execute runs the CLI.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&addrs, "addrs", "amqp://guest:guest@localhost:5672/", "amqp addresses comma separated")
+	rootCmd.PersistentFlags().StringVar(&vhost, "vhost", "/", "vhost")
+	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "log file path")
+	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics-port", 2112, "metrics port")
+
+	rootCmd.AddCommand(newProbeCmd())
+	rootCmd.AddCommand(newSendCmd())
+	rootCmd.AddCommand(newStatusCmd())
+}
+
+func setup() (*conn.Manager, *logrus.Logger, context.Context, context.CancelFunc) {
+	log := logger.New(logFile, logrus.InfoLevel)
+	mgr := conn.New(strings.Split(addrs, ","), vhost, log)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		addr := fmt.Sprintf(":%d", metricsPort)
+		if err := metrics.Start(addr); err != nil {
+			log.WithError(err).Error("metrics failed")
+		}
+	}()
+
+	go mgr.Connect(ctx)
+	return mgr, log, ctx, cancel
+}

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/example/rabbitprobe/internal/sender"
+)
+
+var (
+	sendEx    string
+	sendRK    string
+	sendSize  int
+	sendCount int
+	sendRate  int
+)
+
+func newSendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send",
+		Short: "send random payloads",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mgr, log, ctx, cancel := setup()
+			defer cancel()
+			s := sender.New(mgr, log)
+			p := sender.Params{Exchange: sendEx, Routing: sendRK, Size: sendSize, Count: sendCount, Rate: sendRate}
+			return s.Run(ctx, p)
+		},
+	}
+
+	cmd.Flags().StringVar(&sendEx, "ex", "", "exchange")
+	cmd.Flags().StringVar(&sendRK, "rk", "", "routing key")
+	cmd.Flags().IntVar(&sendSize, "size", 1024, "message size bytes")
+	cmd.Flags().IntVar(&sendCount, "count", 1, "message count")
+	cmd.Flags().IntVar(&sendRate, "rate", 0, "rate per second")
+	return cmd
+}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/example/rabbitprobe/internal/metrics"
+)
+
+func newStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "show connection status",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("connected: %.0f\n", metrics.ConnectedValue())
+		},
+	}
+}

--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -1,0 +1,112 @@
+package conn
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/example/rabbitprobe/internal/metrics"
+)
+
+// Manager handles connection and reconnection.
+type Manager struct {
+	addrs     []string
+	vhost     string
+	mu        sync.Mutex
+	conn      *amqp.Connection
+	log       *logrus.Logger
+	downAt    time.Time
+	connected bool
+}
+
+// New creates a new Manager.
+func New(addrs []string, vhost string, log *logrus.Logger) *Manager {
+	return &Manager{addrs: addrs, vhost: vhost, log: log}
+}
+
+func (m *Manager) dial(addr string) (*amqp.Connection, error) {
+	cfg := amqp.Config{
+		Vhost:     m.vhost,
+		Heartbeat: time.Second,
+		Locale:    "en_US",
+		Dial:      (&net.Dialer{Timeout: time.Second, KeepAlive: 30 * time.Second}).DialContext,
+	}
+	return amqp.DialConfig(addr, cfg)
+}
+
+// Connect establishes connection with retry.
+func (m *Manager) Connect(ctx context.Context) {
+	backoff := 100 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		addr := m.addrs[rand.Intn(len(m.addrs))]
+		conn, err := m.dial(addr)
+		if err != nil {
+			m.log.WithError(err).Error("connect failed")
+			time.Sleep(backoff)
+			if backoff < 5*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+
+		m.mu.Lock()
+		m.conn = conn
+		m.connected = true
+		m.mu.Unlock()
+		metrics.SetConnected(true)
+		m.log.WithField("addr", addr).Info("ConnUp")
+		if !m.downAt.IsZero() {
+			downtime := time.Since(m.downAt)
+			metrics.Downtime.Observe(downtime.Seconds())
+			m.log.WithField("downtime_ms", downtime.Milliseconds()).Info("ConnRecovered")
+			m.downAt = time.Time{}
+		}
+
+		m.waitClose(conn)
+		metrics.SetConnected(false)
+		metrics.DisconnectTotal.Inc()
+		m.mu.Lock()
+		m.conn = nil
+		m.connected = false
+		m.mu.Unlock()
+		m.downAt = time.Now()
+	}
+}
+
+func (m *Manager) waitClose(conn *amqp.Connection) {
+	errCh := make(chan *amqp.Error, 1)
+	conn.NotifyClose(errCh)
+	err := <-errCh
+	if err != nil {
+		m.log.WithError(err).Error("ConnDown")
+	} else {
+		m.log.Info("Conn closed")
+	}
+}
+
+// Channel returns a new channel using current connection.
+func (m *Manager) Channel() (*amqp.Channel, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.conn == nil {
+		return nil, amqp.ErrClosed
+	}
+	return m.conn.Channel()
+}
+
+// Connected returns connection state.
+func (m *Manager) Connected() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.connected
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,30 @@
+package logger
+
+import (
+	"io"
+	"os"
+
+	"github.com/natefinch/lumberjack"
+	"github.com/sirupsen/logrus"
+)
+
+// New creates a logrus logger writing to stdout and rotating file.
+func New(logFile string, level logrus.Level) *logrus.Logger {
+	log := logrus.New()
+	log.SetLevel(level)
+	log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+
+	if logFile != "" {
+		log.SetOutput(io.MultiWriter(&lumberjack.Logger{
+			Filename:   logFile,
+			MaxSize:    100, // megabytes
+			MaxBackups: 5,
+			MaxAge:     30, // days
+			Compress:   false,
+		}, os.Stdout))
+	} else {
+		log.SetOutput(os.Stdout)
+	}
+
+	return log
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	Connected = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "rabbitprobe_connected",
+		Help: "Connection status 0/1",
+	})
+	connectedValue float64
+	RTT            = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "rabbitprobe_rtt_ms",
+		Help:    "Probe RTT in milliseconds",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+	})
+	DisconnectTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "rabbitprobe_disconnect_total",
+		Help: "Total disconnects",
+	})
+	Downtime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "rabbitprobe_downtime_seconds",
+		Help:    "Downtime seconds",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 10),
+	})
+	Throughput = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "rabbitprobe_throughput_msgs_total",
+		Help: "Total messages sent",
+	})
+)
+
+// Start starts metrics HTTP server.
+func Start(addr string) error {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(Connected, RTT, DisconnectTotal, Downtime, Throughput)
+
+	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	return http.ListenAndServe(addr, nil)
+}
+
+// SetConnected sets gauge and value.
+func SetConnected(v bool) {
+	if v {
+		Connected.Set(1)
+		connectedValue = 1
+	} else {
+		Connected.Set(0)
+		connectedValue = 0
+	}
+}
+
+// ConnectedValue returns current value.
+func ConnectedValue() float64 {
+	return connectedValue
+}

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -1,0 +1,72 @@
+package probe
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/example/rabbitprobe/internal/conn"
+	"github.com/example/rabbitprobe/internal/metrics"
+)
+
+// Engine performs periodic publish-confirm probes.
+type Engine struct {
+	manager  *conn.Manager
+	exchange string
+	routing  string
+	interval time.Duration
+	log      *logrus.Logger
+}
+
+// New creates a probe engine.
+func New(mgr *conn.Manager, ex, rk string, interval time.Duration, log *logrus.Logger) *Engine {
+	return &Engine{manager: mgr, exchange: ex, routing: rk, interval: interval, log: log}
+}
+
+// Start starts the probe loop.
+func (e *Engine) Start(ctx context.Context) {
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.ping(ctx)
+		}
+	}
+}
+
+func (e *Engine) ping(ctx context.Context) {
+	ch, err := e.manager.Channel()
+	if err != nil {
+		return
+	}
+	ch.Confirm(false)
+
+	start := time.Now()
+	body := fmt.Sprintf("ping:%d", start.UnixNano())
+	if err := ch.PublishWithContext(ctx, e.exchange, e.routing, false, false, amqp.Publishing{Body: []byte(body)}); err != nil {
+		e.log.WithError(err).Error("probe publish failed")
+		return
+	}
+	confirm := make(chan amqp.Confirmation, 1)
+	ch.NotifyPublish(confirm)
+	select {
+	case c := <-confirm:
+		if !c.Ack {
+			e.log.Error("probe not acked")
+			return
+		}
+		rtt := time.Since(start)
+		metrics.RTT.Observe(float64(rtt.Milliseconds()))
+		e.log.WithField("latency_ms", rtt.Milliseconds()).Info("probe success")
+	case <-time.After(e.interval * 2):
+		e.log.Error("probe timeout")
+		_ = ch.Close()
+	}
+}

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -1,0 +1,82 @@
+package sender
+
+import (
+	"context"
+	"crypto/rand"
+	"time"
+
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+
+	"github.com/example/rabbitprobe/internal/conn"
+	"github.com/example/rabbitprobe/internal/metrics"
+)
+
+// Sender publishes random messages.
+type Sender struct {
+	manager *conn.Manager
+	ex      string
+	rk      string
+	size    int
+	count   int
+	rate    rate.Limiter
+	log     *logrus.Logger
+}
+
+// Params defines send parameters.
+type Params struct {
+	Exchange string
+	Routing  string
+	Size     int
+	Count    int
+	Rate     int // per second
+}
+
+// New returns a sender.
+func New(mgr *conn.Manager, log *logrus.Logger) *Sender {
+	return &Sender{manager: mgr, log: log}
+}
+
+// Run performs sending.
+func (s *Sender) Run(ctx context.Context, p Params) error {
+	s.ex = p.Exchange
+	s.rk = p.Routing
+	s.size = p.Size
+	s.count = p.Count
+	if p.Rate > 0 {
+		s.rate = *rate.NewLimiter(rate.Limit(p.Rate), p.Rate)
+	}
+
+	ch, err := s.manager.Channel()
+	if err != nil {
+		return err
+	}
+	ch.Confirm(false)
+	confirm := ch.NotifyPublish(make(chan amqp.Confirmation, 1))
+
+	buf := make([]byte, s.size)
+	for i := 0; i < s.count; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.rate.Limit() > 0 {
+			if err := s.rate.Wait(ctx); err != nil {
+				return err
+			}
+		}
+		rand.Read(buf)
+		start := time.Now()
+		if err := ch.PublishWithContext(ctx, s.ex, s.rk, false, false, amqp.Publishing{Body: buf}); err != nil {
+			return err
+		}
+		c := <-confirm
+		if !c.Ack {
+			return amqp.ErrClosed
+		}
+		rtt := time.Since(start)
+		metrics.Throughput.Inc()
+		metrics.RTT.Observe(float64(rtt.Milliseconds()))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a CLI tool `rabbitprobe` for probing and load testing RabbitMQ
- implement connection manager with automatic reconnect and metrics reporting
- implement probe engine, load sender, and CLI commands
- expose Prometheus metrics and rotating logging
- update README with build and usage instructions

## Testing
- `gofmt -w internal/logger/logger.go internal/metrics/metrics.go internal/conn/manager.go internal/probe/probe.go internal/sender/sender.go internal/cmd/*.go cmd/rabbitprobe/main.go`
- `go vet ./...` *(fails: no required module provides package github.com/rabbitmq/amqp091-go etc.)*
- `go build ./...` *(fails: no required module provides package github.com/rabbitmq/amqp091-go etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6889e16fb0088326bc263c068694a7e2