### PR TITLE
Add Dockerfile for building rabbitprobe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.24 AS builder
+WORKDIR /app
+
+# Copy go module files and download dependencies first for caching
+COPY go.mod ./
+RUN go mod download
+
+# Copy the rest of the source
+COPY . .
+
+# Build the rabbitprobe binary
+RUN go build -o rabbitprobe ./cmd/rabbitprobe
+
+# Final stage
+FROM debian:stable-slim
+WORKDIR /usr/local/bin
+COPY --from=builder /app/rabbitprobe .
+
+# Default command shows help
+ENTRYPOINT ["rabbitprobe"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build for the rabbitprobe CLI
- update to use Go 1.24 base image

## Testing
- `go mod tidy` *(fails: proxy.golang.org Forbidden)*
- `go build ./cmd/rabbitprobe` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6889e2f13e908326a6215fbf983aa768