### PR TITLE
Fix amqp import alias

### DIFF
--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rabbitmq/amqp091-go"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/sirupsen/logrus"
 
 	"github.com/example/rabbitprobe/internal/metrics"

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/rabbitmq/amqp091-go"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/sirupsen/logrus"
 
 	"github.com/example/rabbitprobe/internal/conn"

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"time"
 
-	"github.com/rabbitmq/amqp091-go"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 


### PR DESCRIPTION
## Summary
- use `amqp` alias for `github.com/rabbitmq/amqp091-go`

## Testing
- `go build ./cmd/rabbitprobe` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_688ada5aa670832696f12602eba42c86