### PR TITLE
Fix dial function type mismatch

### DIFF
--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -34,7 +34,7 @@ func (m *Manager) dial(addr string) (*amqp.Connection, error) {
 		Vhost:     m.vhost,
 		Heartbeat: time.Second,
 		Locale:    "en_US",
-		Dial:      (&net.Dialer{Timeout: time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		Dial:      (&net.Dialer{Timeout: time.Second, KeepAlive: 30 * time.Second}).Dial,
 	}
 	return amqp.DialConfig(addr, cfg)
 }


### PR DESCRIPTION
## Summary
- correct dialer function to use `Dial` instead of `DialContext`

## Testing
- `go mod tidy` *(fails: module downloads blocked)*
- `go build ./cmd/rabbitprobe` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688adcf8d2588326ad5a8dce3eaccb58