### PR TITLE
Fix default Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ FROM debian:stable-slim
 WORKDIR /usr/local/bin
 COPY --from=builder /app/rabbitprobe .
 
-# Default command shows help
+# Run probe by default
 ENTRYPOINT ["rabbitprobe"]
-CMD ["--help"]
+CMD ["probe", "start"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Send 100 messages:
 ./rabbitprobe send --ex data.ex --rk test --size 1024 --count 100
 ```
 
+## Running the container
+
+The provided `Dockerfile` builds an image that runs `rabbitprobe probe start`
+by default. To run other commands, override the container command, e.g.:
+
+```
+docker run myimage rabbitprobe send --ex data.ex --rk test --size 1024 --count 100
+```
+
 ## Stopping the probe
 
 `probe start` will keep a connection to RabbitMQ open until the process is


### PR DESCRIPTION
## Summary
- run `rabbitprobe probe start` as default container command so it doesn't exit immediately
- clarify container usage in README

## Testing
- `go vet ./...`
- `go build ./cmd/rabbitprobe`


------
https://chatgpt.com/codex/tasks/task_e_688ae3472ee48326bec08a9e9a769480