### PR TITLE
Allow interactive use without overriding entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,5 @@ FROM debian:stable-slim
 WORKDIR /usr/local/bin
 COPY --from=builder /app/rabbitprobe .
 
-# Run probe by default
-ENTRYPOINT ["rabbitprobe"]
-CMD ["probe", "start"]
+# Keep container running for interactive use
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Send 100 messages:
 
 ## Running the container
 
-The provided `Dockerfile` builds an image that runs `rabbitprobe probe start`
-by default. To run other commands, override the container command, e.g.:
+The provided `Dockerfile` builds an image that keeps the container running with
+`sleep infinity` by default. Exec into the container to run `rabbitprobe`
+manually or override the command when starting the container, e.g.:
 
 ```
 docker run myimage rabbitprobe send --ex data.ex --rk test --size 1024 --count 100


### PR DESCRIPTION
## Summary
- keep container alive with `sleep infinity` by default
- clarify container behaviour in README

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688ae775fa1083269ee0166f110191f2